### PR TITLE
Add gh workflow for prod apk build + publish, plus manual build scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,51 @@
+name: 🔧 Build and Release
+
+on:
+  release:
+    types: [published]
+  # Allow manual trigger (workflow_dispatch)
+  workflow_dispatch:
+
+jobs:
+  build_upload_apk:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    container:
+        image: docker.io/cimg/android:2025.09
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Compile Code
+        run: ./gradlew assembleDebug
+
+      - name: Install Github CLI
+        run: |
+          sudo apt update
+          sudo apt install --no-install-recommends -y gh
+
+      - name: Prod Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # keystore is base64 encoded secret string, first decode
+          echo "${{ secrets.KEYSTORE_FILE_BASE64 }}" | base64 --decode > "$GITHUB_WORKSPACE/${{ secrets.KEYSTORE_NAME }}"
+
+          # Verify the keystore file is correctly created
+          echo "Current dir: ${PWD}"
+          echo "Keystore location: $GITHUB_WORKSPACE/${{ secrets.KEYSTORE_NAME }}"
+          ls -la "$GITHUB_WORKSPACE"
+
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file=$GITHUB_WORKSPACE/${{ secrets.KEYSTORE_NAME }}" \
+            -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_STOREPASS }} \
+            -Pandroid.injected.signing.key.alias=${{ secrets.KEYSTORE_ALIAS }} \
+            -Pandroid.injected.signing.key.password=${{ secrets.KEYSTORE_KEYPASS }}
+
+          signed_apk_path=$(find ./app/build/outputs/apk/release -name '*.apk' -type f)
+          echo "Generated APK file: ${signed_apk_path}"
+
+          gh release upload ${{ github.event.release.tag_name }} "${signed_apk_path}"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+scripts/*jks

--- a/scripts/build_prod.sh
+++ b/scripts/build_prod.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PASSWORD:?Environment variable PASSWORD must be set}"
+
+# Get absolute directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KEYSTORE_PATH="${SCRIPT_DIR}/hotosm.jks"
+
+./gradlew assembleDebug
+
+./gradlew assembleRelease \
+  -Pandroid.injected.signing.store.file="${KEYSTORE_PATH}" \
+  -Pandroid.injected.signing.store.password="${PASSWORD}" \
+  -Pandroid.injected.signing.key.alias=hotosm-android \
+  -Pandroid.injected.signing.key.password="${PASSWORD}"

--- a/scripts/build_prod.sh
+++ b/scripts/build_prod.sh
@@ -3,14 +3,20 @@ set -euo pipefail
 
 : "${PASSWORD:?Environment variable PASSWORD must be set}"
 
-# Get absolute directory of this script
+# Resolve dirs
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 KEYSTORE_PATH="${SCRIPT_DIR}/hotosm.jks"
 
-./gradlew assembleDebug
-
-./gradlew assembleRelease \
-  -Pandroid.injected.signing.store.file="${KEYSTORE_PATH}" \
-  -Pandroid.injected.signing.store.password="${PASSWORD}" \
-  -Pandroid.injected.signing.key.alias=hotosm-android \
-  -Pandroid.injected.signing.key.password="${PASSWORD}"
+docker run --rm \
+  -v "$PROJECT_DIR":"$PROJECT_DIR" \
+  --workdir "$PROJECT_DIR" \
+  docker.io/cimg/android:2025.09 \
+  bash -c "
+    ./gradlew assembleDebug &&
+    ./gradlew assembleRelease \
+      -Pandroid.injected.signing.store.file='${KEYSTORE_PATH}' \
+      -Pandroid.injected.signing.store.password='${PASSWORD}' \
+      -Pandroid.injected.signing.key.alias=hotosm-android \
+      -Pandroid.injected.signing.key.password='${PASSWORD}'
+  "

--- a/scripts/gen_keystore.sh
+++ b/scripts/gen_keystore.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# NOTE for PKCS12 keystores, the store pass and key pass will be the same
+: "${PASSWORD:?Environment variable PASSWORD must be set}"
+
+keytool -genkeypair -v \
+  -keystore scripts/hotosm.jks \
+  -alias hotosm-android \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000 \
+  -storepass "$PASSWORD" \
+  -keypass "$PASSWORD" \
+  -dname "CN=HOT, OU=Dev, O=Humanitarian OpenStreetMap Team, L=Global, ST=Earth, C=US"

--- a/scripts/gen_keystore.sh
+++ b/scripts/gen_keystore.sh
@@ -4,12 +4,19 @@ set -euo pipefail
 # NOTE for PKCS12 keystores, the store pass and key pass will be the same
 : "${PASSWORD:?Environment variable PASSWORD must be set}"
 
-keytool -genkeypair -v \
-  -keystore scripts/hotosm.jks \
-  -alias hotosm-android \
-  -keyalg RSA \
-  -keysize 2048 \
-  -validity 10000 \
-  -storepass "$PASSWORD" \
-  -keypass "$PASSWORD" \
-  -dname "CN=HOT, OU=Dev, O=Humanitarian OpenStreetMap Team, L=Global, ST=Earth, C=US"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+docker run --rm \
+  -v "$PROJECT_DIR":"$PROJECT_DIR" \
+  --workdir "$PROJECT_DIR" \
+  docker.io/cimg/android:2025.09 \
+  keytool -genkeypair -v \
+    -keystore "$SCRIPT_DIR/hotosm.jks" \
+    -alias hotosm-android \
+    -keyalg RSA \
+    -keysize 2048 \
+    -validity 10000 \
+    -storepass "$PASSWORD" \
+    -keypass "$PASSWORD" \
+    -dname "CN=HOT, OU=Dev, O=Humanitarian OpenStreetMap Team, L=Global, ST=Earth, C=US"


### PR DESCRIPTION
Fixes #73 

- Added a workflow if we want to publish as github release.
- Added scripts for generating signing key + signing a release for Play store.